### PR TITLE
Updates to the schedule

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: workshop      # DON'T CHANGE THIS.
 carpentry: "swc"    # what kind of Carpentry (must be either "lc" or "dc" or "swc").  
                       # Be sure to update the Carpentry type in _config.yml as well.  
 venue: "Data Carpentry Workshop at University of Central Oklahoma (EDMOND)"        # brief name of host site without address (e.g., "Euphoric State University")
-address: "Room 120, Donald Betz STEM Research and Learning Center,East Main St. and Garland Godfrey Dr.,University of Central Oklahoma, Edmond, OK 73034"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
+address: "Room 120, Donald Betz STEM Research and Learning Center, East Main St. and Garland Godfrey Dr.,University of Central Oklahoma, Edmond, OK 73034"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "us"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes)
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
 latlng: "35.655861,-97.475029"       # decimal latitude and longitude of workshop venue (e.g., "41.7901128,-87.6007318" - use https://www.latlong.net/)

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ country: "us"      # lowercase two-letter ISO country code such as "fr" (see htt
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
 latlng: "35.655861,-97.475029"       # decimal latitude and longitude of workshop venue (e.g., "41.7901128,-87.6007318" - use https://www.latlong.net/)
 humandate: "August 12-14,2019"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
-humantime: "9:00 am - 5:00 pm on 12th August 2019, 1:00 pm - 4:00 pm on 13th and 14th August 2019"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
+humantime: "8:30 am - 4:00 pm on 12th August 2019, 1:00 pm - 4:00 pm on 13th and 14th August 2019"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: 2019-08-12      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2019-08-14        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["Jamie Hadwin"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]


### PR DESCRIPTION
Some final changes. Keep the first day times in the header as they were. The "Schedule section" below is correct. Sorry for the confusion. My email confused things.